### PR TITLE
Improve Actor attribute allowing provider but no state name

### DIFF
--- a/src/CloudActors.CodeAnalysis/ActorStateGenerator.cs
+++ b/src/CloudActors.CodeAnalysis/ActorStateGenerator.cs
@@ -44,19 +44,15 @@ public class ActorStateGenerator : IIncrementalGenerator
                 .Select(x => new Member(x.Name, x.Type.GetTypeName(ns)));
 
             var members = props.Concat(fields).ToArray();
-            if (members.Length > 0)
-            {
-                var es = actor.AllInterfaces.Any(x => x.ToDisplayString(FullName) == "Devlooped.CloudActors.IEventSourced");
+            var es = actor.AllInterfaces.Any(x => x.ToDisplayString(FullName) == "Devlooped.CloudActors.IEventSourced");
+            var model = new StateModel(
+                Namespace: ns,
+                Name: actor.Name,
+                Members: members,
+                EventSourced: es);
 
-                var model = new StateModel(
-                    Namespace: ns,
-                    Name: actor.Name,
-                    Members: members,
-                    EventSourced: es);
-
-                var output = template.Render(model, member => member.Name);
-                ctx.AddSource($"{actor.ToFileName()}.State.cs", output);
-            }
+            var output = template.Render(model, member => member.Name);
+            ctx.AddSource($"{actor.ToFileName()}.State.cs", output);
         });
     }
 

--- a/src/CloudActors.Server.CodeAnalysis/ActorGrain.sbntxt
+++ b/src/CloudActors.Server.CodeAnalysis/ActorGrain.sbntxt
@@ -20,8 +20,10 @@ public partial class {{ Name }}Grain : Grain, IActorGrain
 {
     readonly IActorPersistentState<{{ Name }}.ActorState, {{ Name }}> storage;
 
-    {{~ if StorageName ~}}
-    public {{ Name }}Grain([PersistentState("{{ StateName }}", "{{ StorageName }}")] IPersistentState<{{ Name }}.ActorState> storage)
+    {{~ if StorageProvider && StateName ~}}
+    public {{ Name }}Grain([PersistentState("{{ StateName }}", "{{ StorageProvider }}")] IPersistentState<{{ Name }}.ActorState> storage)
+    {{~ else if StorageProvider ~}}
+    public {{ Name }}Grain([PersistentState(nameof({{ Name }}), "{{ StorageProvider }}")] IPersistentState<{{ Name }}.ActorState> storage)
     {{~ else if StateName ~}}
     public {{ Name }}Grain([PersistentState("{{ StateName }}")] IPersistentState<{{ Name }}.ActorState> storage)
     {{~ else ~}}

--- a/src/CloudActors.Server.CodeAnalysis/ActorGrainGenerator.cs
+++ b/src/CloudActors.Server.CodeAnalysis/ActorGrainGenerator.cs
@@ -26,16 +26,18 @@ public class ActorGrainGenerator : IIncrementalGenerator
             var attribute = actor.GetAttributes().First(x => x.IsActor());
             var state = default(string);
             var storage = default(string);
-            if (attribute.ConstructorArguments.Length >= 1)
+            if (attribute.ConstructorArguments.Length >= 1 &&
+                !attribute.ConstructorArguments[0].IsNull)
                 state = attribute.ConstructorArguments[0].Value?.ToString() ?? null;
-            if (attribute.ConstructorArguments.Length == 2)
+            if (attribute.ConstructorArguments.Length == 2 &&
+                !attribute.ConstructorArguments[1].IsNull)
                 storage = attribute.ConstructorArguments[1].Value?.ToString() ?? null;
 
             var model = new GrainModel(
                 Namespace: actor.ContainingNamespace.ToDisplayString(),
                 Name: actor.Name,
                 StateName: state,
-                StorageName: storage,
+                StorageProvider: storage,
                 Version: ThisAssembly.Info.InformationalVersion,
                 Queries: actor.GetMembers().OfType<IMethodSymbol>().Where(IsQuery).Select(ToOperation),
                 Commands: actor.GetMembers().OfType<IMethodSymbol>().Where(IsCommand).Select(ToOperation),
@@ -60,7 +62,7 @@ public class ActorGrainGenerator : IIncrementalGenerator
 
     record GrainOperation(string Name, string Type, bool IsAsync);
 
-    record GrainModel(string Namespace, string Name, string? StateName, string? StorageName, string Version,
+    record GrainModel(string Namespace, string Name, string? StateName, string? StorageProvider, string Version,
         IEnumerable<GrainOperation> Queries, IEnumerable<GrainOperation> Commands, IEnumerable<GrainOperation> VoidCommands)
     {
         public bool QueryAsync => Queries.Any(x => x.IsAsync);

--- a/src/CloudActors.Server.CodeAnalysis/ActorsAssemblyGenerator.cs
+++ b/src/CloudActors.Server.CodeAnalysis/ActorsAssemblyGenerator.cs
@@ -51,8 +51,9 @@ public class ActorsAssemblyGenerator : IIncrementalGenerator
             output.AppendLine($"[assembly: ApplicationPartAttribute(\"{assembly.Name}\")]");
         }
 
-        foreach (var type in assemblies.Select(x => x.GetAllTypes()
-            .FirstOrDefault(x => x.MetadataName != "<Module>" && x.ContainingType == null && options.Compilation.IsSymbolAccessibleWithin(x, options.Compilation.Assembly))))
+        foreach (var type in assemblies.Select(x => x.GetAllTypes().FirstOrDefault(x =>
+                x.MetadataName != "<Module>" && x.MetadataName != "ActorBusExtensions" && x.MetadataName != "CloudActorsAttribute" &&
+                x.ContainingType == null && options.Compilation.IsSymbolAccessibleWithin(x, options.Compilation.Assembly))))
         {
             if (type == null)
                 continue;

--- a/src/CloudActors/ActorAttribute.cs
+++ b/src/CloudActors/ActorAttribute.cs
@@ -2,25 +2,19 @@
 
 namespace Devlooped.CloudActors;
 
-/// <summary>
-/// Flags the decorated class as an actor.
-/// </summary>
+/// <summary>Flags the decorated class as an actor.</summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class ActorAttribute : Attribute
 {
-    /// <summary>
-    /// The actor uses the type name of the annotated class as the state 
-    /// name and the default storage provider.
-    /// </summary>
+    /// <summary>The actor uses the type name of the annotated class as the state name and the default storage provider.</summary>
     public ActorAttribute() { }
 
-    /// <summary>
-    /// The actor uses the given state name and the default storage provider.
-    /// </summary>
+    /// <summary>The actor uses the given state name and the default storage provider.</summary>
+    /// <param name="stateName">Use a state name other than the type name.</param>
     public ActorAttribute(string stateName) { }
 
-    /// <summary>
-    /// The actor uses the given state name and storage provider.
-    /// </summary>
-    public ActorAttribute(string stateName, string storageName) { }
+    /// <summary>The actor uses the given state name and storage provider.</summary>
+    /// <param name="stateName">Use a state name other than the type name.</param>
+    /// <param name="storageProvider">Storage provider name registered with Orleans.</param>
+    public ActorAttribute(string? stateName = default, string? storageProvider = default) { }
 }

--- a/src/Tests/GrainsGeneration.cs
+++ b/src/Tests/GrainsGeneration.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Devlooped.CloudActors;
+using Orleans.Runtime;
+
+namespace Tests;
+
+public class GrainsGeneration
+{
+    [Fact]
+    public void GrainWithNoArgs()
+    {
+        var ctor = typeof(ActorWithNoArgsGrain).GetConstructors()[0];
+        Assert.Single(ctor.GetParameters());
+
+        var attr = ctor.GetParameters()[0].GetCustomAttribute<PersistentStateAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal(nameof(ActorWithNoArgs), attr.StateName);
+        Assert.Null(attr.StorageName);
+    }
+
+    [Fact]
+    public void GrainWithStateName()
+    {
+        var ctor = typeof(ActorWithStateNameGrain).GetConstructors()[0];
+        Assert.Single(ctor.GetParameters());
+
+        var attr = ctor.GetParameters()[0].GetCustomAttribute<PersistentStateAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal("Foo", attr.StateName);
+        Assert.Null(attr.StorageName);
+    }
+
+    [Fact]
+    public void GrainWithStorageProvider()
+    {
+        var ctor = typeof(ActorWithStorageProviderGrain).GetConstructors()[0];
+        Assert.Single(ctor.GetParameters());
+
+        var attr = ctor.GetParameters()[0].GetCustomAttribute<PersistentStateAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal(nameof(ActorWithStorageProvider), attr.StateName);
+        Assert.Equal("Bar", attr.StorageName);
+    }
+
+    [Fact]
+    public void GrainWithStateNameAndStorageProvider()
+    {
+        var ctor = typeof(ActorWithStateAndStorageProviderGrain).GetConstructors()[0];
+        Assert.Single(ctor.GetParameters());
+
+        var attr = ctor.GetParameters()[0].GetCustomAttribute<PersistentStateAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal("Foo", attr.StateName);
+        Assert.Equal("Bar", attr.StorageName);
+    }
+}
+
+[Actor]
+public partial class ActorWithNoArgs(string id)
+{
+    [IgnoreDataMember]
+    public string Id => id;
+}
+
+[Actor("Foo")]
+public partial class ActorWithStateName(string id)
+{
+    [IgnoreDataMember]
+    public string Id => id;
+}
+
+[Actor(storageProvider: "Bar")]
+public partial class ActorWithStorageProvider(string id)
+{
+    [IgnoreDataMember]
+    public string Id => id;
+}
+
+[Actor("Foo", "Bar")]
+public partial class ActorWithStateAndStorageProvider(string id)
+{
+    [IgnoreDataMember]
+    public string Id => id;
+}


### PR DESCRIPTION
This preserves the default value for StateName == nameof(T) so the uesr can just override the storage provider.

The tests also exercised a scenario previously generating a build error: an actor with no state (beyond its ctor-provided ID). We need to generate the inner state class always because otherwise the grain generator fails.

Cleanup also more duplicate declaration warnings by avoiding using types we emit for bringing in codegen from Orleans via `GenerateCodeForDeclaringAssembly`.