### PR TITLE
Implement DCA005 diagnostic for non-serializable actor state types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,7 @@ ID format stored in Orleans: `"{actortype}/{id}"` (e.g. `"account/42"`, `"produc
 | `DCA002` | Error | Do not manually add `[GenerateSerializer]` — it is added automatically |
 | `DCA003` | Error | Message types may only implement one of `IActorCommand`, `IActorCommand<T>`, `IActorQuery<T>` |
 | `DCA004` | Error | `<ProduceReferenceAssembly>true</ProduceReferenceAssembly>` is not supported in actor projects |
+| `DCA005` | Error | Actor state types must be serializable — make `partial` or add `[GenerateSerializer]` |
 
 ---
 

--- a/src/CloudActors.Abstractions.CodeAnalysis/ActorStateGenerator.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/ActorStateGenerator.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Scriban;
 using static Devlooped.CloudActors.AnalysisExtensions;
@@ -18,6 +20,8 @@ class ActorStateGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        var config = context.GetOrleansConfig();
+
         var actors = context.SyntaxProvider.CreateSyntaxProvider(
             predicate: static (node, _) =>
                 node is ClassDeclarationSyntax cds &&
@@ -36,7 +40,7 @@ class ActorStateGenerator : IIncrementalGenerator
                     .OfType<IMethodSymbol>()
                     .Any(m => m.IsStatic && m.Parameters.Length == 0) == true;
 
-                return ModelExtractors.ExtractActorModel(symbol, iParsable, hasCreateVersion7);
+                return ModelExtractors.ExtractActorModel(symbol, iParsable, hasCreateVersion7, ctx.SemanticModel.Compilation);
             })
             .Where(static x => x != null)
             .Select(static (x, _) => x!.Value)
@@ -61,5 +65,25 @@ class ActorStateGenerator : IIncrementalGenerator
             var output = template.Render(model, member => member.Name);
             ctx.AddSource($"{actor.FileName}.State.cs", output);
         });
+
+        // Generate [GenerateSerializer] for partial user-defined types found in actor state
+        var stateTypes = actors
+            .SelectMany(static (actor, _) => actor.StateTypes.AsImmutableArray())
+            .Collect()
+            .SelectMany(static (types, _) => types.Distinct().ToImmutableArray())
+            .WithTrackingName(TrackingNames.StateSerializableTypes);
+
+        context.RegisterImplementationSourceOutput(
+            stateTypes.Combine(config).Combine(context.CompilationProvider).Combine(context.ParseOptionsProvider),
+            (ctx, source) =>
+            {
+                var (((type, config), compilation), parseOptions) = source;
+
+                if (config.ProduceReferenceAssembly)
+                    return;
+
+                ctx.GenerateCode(type.Name, type.Namespace, type.FullName, type.IsRecord,
+                    config, compilation, parseOptions as CSharpParseOptions);
+            });
     }
 }

--- a/src/CloudActors.Abstractions.CodeAnalysis/ActorStateSerializableAnalyzer.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/ActorStateSerializableAnalyzer.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static Devlooped.CloudActors.Diagnostics;
+
+namespace Devlooped.CloudActors;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+class ActorStateSerializableAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(MustBeSerializable);
+
+#if DEBUG
+#pragma warning disable RS1026 // Enable concurrent execution: we only turn this on in release builds
+#endif
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+#if !DEBUG
+        context.EnableConcurrentExecution();
+#endif
+        context.RegisterCompilationStartAction(startContext =>
+        {
+            var generateSerializerAttr = startContext.Compilation.GetTypeByMetadataName("Orleans.GenerateSerializerAttribute");
+
+            // Pre-compute the set of types referenced by actor state that need serialization.
+            var stateTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+            foreach (var actor in startContext.Compilation.Assembly.GetAllTypes()
+                .OfType<INamedTypeSymbol>()
+                .Where(t => t.GetAttributes().Any(a => a.IsActor())))
+            {
+                var visited = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+                var candidates = new List<INamedTypeSymbol>();
+
+                foreach (var prop in actor.GetMembers().OfType<IPropertySymbol>()
+                    .Where(x => x.CanBeReferencedByName && !x.IsIndexer && !x.IsAbstract && x.SetMethod != null))
+                {
+                    AnalysisExtensions.WalkTypeForSerialization(prop.Type, visited, candidates);
+                }
+
+                foreach (var field in actor.GetMembers().OfType<IFieldSymbol>()
+                    .Where(x => x.CanBeReferencedByName && !x.IsConst && !x.IsStatic && !x.IsReadOnly))
+                {
+                    AnalysisExtensions.WalkTypeForSerialization(field.Type, visited, candidates);
+                }
+
+                foreach (var c in candidates)
+                    stateTypes.Add(c);
+            }
+
+            // Report locally on each type declaration via syntax node action,
+            // so VS shows the diagnostic immediately in the editor.
+            startContext.RegisterSyntaxNodeAction(nodeContext =>
+            {
+                if (nodeContext.Node is not TypeDeclarationSyntax typeDecl)
+                    return;
+
+                var type = nodeContext.SemanticModel.GetDeclaredSymbol(typeDecl);
+                if (type == null || !stateTypes.Contains(type))
+                    return;
+
+                if (type.IsActor() || type.IsActorMessage())
+                    return;
+
+                if (type.IsPartial())
+                    return;
+
+                if (generateSerializerAttr != null && type.GetAttributes()
+                    .Any(a => a.AttributeClass?.Equals(generateSerializerAttr, SymbolEqualityComparer.Default) == true))
+                    return;
+
+                nodeContext.ReportDiagnostic(Diagnostic.Create(
+                    MustBeSerializable, typeDecl.Identifier.GetLocation(), type.Name));
+            }, SyntaxKind.ClassDeclaration, SyntaxKind.RecordDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.RecordStructDeclaration);
+        });
+    }
+}

--- a/src/CloudActors.Abstractions.CodeAnalysis/AnalysisExtensions.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/AnalysisExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -74,4 +75,155 @@ static class AnalysisExtensions
     public static bool IsPartial(this ITypeSymbol node) => node.DeclaringSyntaxReferences.Any(
         r => r.GetSyntax() is TypeDeclarationSyntax { Modifiers: { } modifiers } &&
             modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)));
+
+    /// <summary>
+    /// Returns true if the type is a user-defined type that may need Orleans serialization:
+    /// declared in source, not a primitive/enum/delegate/interface, not in System.* or Orleans.* namespaces.
+    /// </summary>
+    public static bool IsUserDefinedSerializableCandidate(this INamedTypeSymbol type)
+    {
+        if (!type.Locations.Any(l => l.IsInSource))
+            return false;
+        if (type.SpecialType != SpecialType.None)
+            return false;
+        if (type.TypeKind is TypeKind.Enum or TypeKind.Delegate or TypeKind.Interface)
+            return false;
+
+        var ns = type.ContainingNamespace?.ToDisplayString();
+        if (ns != null && (ns.StartsWith("System") || ns.StartsWith("Orleans")))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Recursively walks a type tree collecting user-defined types that need serialization.
+    /// Handles arrays, generic type arguments, and nested public properties.
+    /// </summary>
+    public static void WalkTypeForSerialization(
+        ITypeSymbol type,
+        HashSet<ITypeSymbol> visited,
+        List<INamedTypeSymbol> results)
+    {
+        if (!visited.Add(type))
+            return;
+
+        // Handle arrays
+        if (type is IArrayTypeSymbol arr)
+        {
+            WalkTypeForSerialization(arr.ElementType, visited, results);
+            return;
+        }
+
+        if (type is not INamedTypeSymbol named)
+            return;
+
+        // Walk generic type arguments (List<T>, Dictionary<K,V>, Nullable<T>, etc.)
+        foreach (var arg in named.TypeArguments)
+            WalkTypeForSerialization(arg, visited, results);
+
+        if (!named.IsUserDefinedSerializableCandidate())
+            return;
+
+        // This is a user-defined type that needs serialization
+        results.Add(named);
+
+        // Recursively walk its public properties to find nested types
+        foreach (var prop in named.GetMembers().OfType<IPropertySymbol>()
+            .Where(p => p.DeclaredAccessibility == Accessibility.Public))
+        {
+            WalkTypeForSerialization(prop.Type, visited, results);
+        }
+
+        // Also walk public fields (e.g. record positional parameters)
+        foreach (var field in named.GetMembers().OfType<IFieldSymbol>()
+            .Where(f => f.DeclaredAccessibility == Accessibility.Public && !f.IsConst && !f.IsStatic))
+        {
+            WalkTypeForSerialization(field.Type, visited, results);
+        }
+    }
+
+    /// <summary>
+    /// Collects partial user-defined types from actor state members as <see cref="SerializableTypeModel"/> values.
+    /// Used by the generator pipeline to emit [GenerateSerializer] for state-referenced types.
+    /// Skips types already handled by ActorMessageGenerator (message types and their additional types).
+    /// </summary>
+    public static ImmutableArray<SerializableTypeModel> CollectStateSerializableTypes(
+        INamedTypeSymbol actor, string actorNamespace, Compilation compilation)
+    {
+        var visited = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+        var candidates = new List<INamedTypeSymbol>();
+
+        // Walk writable properties (same criteria as ActorStateGenerator)
+        foreach (var prop in actor.GetMembers().OfType<IPropertySymbol>()
+            .Where(x => x.CanBeReferencedByName && !x.IsIndexer && !x.IsAbstract && x.SetMethod != null))
+        {
+            WalkTypeForSerialization(prop.Type, visited, candidates);
+        }
+
+        // Walk mutable fields
+        foreach (var field in actor.GetMembers().OfType<IFieldSymbol>()
+            .Where(x => x.CanBeReferencedByName && !x.IsConst && !x.IsStatic && !x.IsReadOnly))
+        {
+            WalkTypeForSerialization(field.Type, visited, candidates);
+        }
+
+        // Collect types already handled by ActorMessageGenerator (message additional types)
+        var messageAdditionalTypes = CollectMessageAdditionalTypes(compilation);
+
+        // Only return partial, non-actor, non-message types not already covered by message generation
+        return candidates
+            .Where(t => t.IsPartial() && !t.IsActorMessage() && !t.IsActor() &&
+                !messageAdditionalTypes.Contains(t))
+            .Select(t => new SerializableTypeModel(
+                t.Name,
+                t.ContainingNamespace.IsGlobalNamespace ? "" : t.ContainingNamespace.ToDisplayString(),
+                t.ToDisplayString(FullName),
+                t.IsRecord))
+            .Distinct()
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Collects all types that ActorMessageGenerator will generate [GenerateSerializer] for,
+    /// to avoid duplicate generation from ActorStateGenerator.
+    /// </summary>
+    static HashSet<INamedTypeSymbol> CollectMessageAdditionalTypes(Compilation compilation)
+    {
+        var messageType = compilation.GetTypeByMetadataName("Devlooped.CloudActors.IActorMessage");
+        var result = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        if (messageType == null)
+            return result;
+
+        // Find all message types in the current assembly
+        foreach (var type in compilation.Assembly.GetAllTypes().OfType<INamedTypeSymbol>())
+        {
+            if (!type.AllInterfaces.Contains(messageType, SymbolEqualityComparer.Default) || !type.IsPartial())
+                continue;
+
+            // The message itself is handled
+            result.Add(type);
+
+            // Collect additional types from public properties/parameters (same logic as ExtractActorMessageModel)
+            foreach (var prop in type.GetMembers().OfType<IPropertySymbol>()
+                .Where(p => p.DeclaredAccessibility == Accessibility.Public))
+            {
+                if (prop.Type is INamedTypeSymbol propType && propType.IsPartial() && !propType.IsActorMessage())
+                    result.Add(propType);
+            }
+
+            foreach (var method in type.GetMembers().OfType<IMethodSymbol>()
+                .Where(m => m.DeclaredAccessibility == Accessibility.Public))
+            {
+                foreach (var param in method.Parameters)
+                {
+                    if (param.Type is INamedTypeSymbol paramType && paramType.IsPartial() && !paramType.IsActorMessage())
+                        result.Add(paramType);
+                }
+            }
+        }
+
+        return result;
+    }
 }

--- a/src/CloudActors.Abstractions.CodeAnalysis/CacheableModels.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/CacheableModels.cs
@@ -36,7 +36,9 @@ record struct ActorModel(
     /// <summary>Whether the ID type implements IParsable or is a StructId.</summary>
     bool IsTypedId,
     /// <summary>Whether the Guid type has CreateVersion7 method (for primitive Guid IDs).</summary>
-    bool HasGuidCreateVersion7) : IEquatable<ActorModel>
+    bool HasGuidCreateVersion7,
+    /// <summary>Partial user-defined types referenced from actor state that need [GenerateSerializer].</summary>
+    EquatableArray<SerializableTypeModel> StateTypes) : IEquatable<ActorModel>
 {
     public string FileName => FullName.Replace('+', '.');
 }
@@ -165,7 +167,7 @@ static class ModelExtractors
     /// Extracts an <see cref="ActorModel"/> from a declared actor symbol.
     /// Must be called inside a pipeline transform lambda where semantic model is available.
     /// </summary>
-    public static ActorModel? ExtractActorModel(INamedTypeSymbol actor, INamedTypeSymbol? iParsable, bool hasGuidCreateVersion7)
+    public static ActorModel? ExtractActorModel(INamedTypeSymbol actor, INamedTypeSymbol? iParsable, bool hasGuidCreateVersion7, Compilation? compilation = null)
     {
         if (actor.ContainingType != null)
             return null;
@@ -219,6 +221,11 @@ static class ModelExtractors
         // Extract ID info
         var (idTypeFullName, isPrimitiveId, isTypedId) = ExtractIdInfo(actor, iParsable);
 
+        // Collect partial user-defined types from state members that need [GenerateSerializer]
+        var stateTypes = compilation != null
+            ? AnalysisExtensions.CollectStateSerializableTypes(actor, ns, compilation)
+            : ImmutableArray<SerializableTypeModel>.Empty;
+
         return new ActorModel(
             Name: actor.Name,
             Namespace: ns,
@@ -235,7 +242,8 @@ static class ModelExtractors
             IdTypeFullName: idTypeFullName,
             IsPrimitiveId: isPrimitiveId,
             IsTypedId: isTypedId,
-            HasGuidCreateVersion7: hasGuidCreateVersion7);
+            HasGuidCreateVersion7: hasGuidCreateVersion7,
+            StateTypes: stateTypes);
     }
 
     static (string? IdTypeFullName, bool IsPrimitive, bool IsTypedId) ExtractIdInfo(

--- a/src/CloudActors.Abstractions.CodeAnalysis/Diagnostics.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/Diagnostics.cs
@@ -39,4 +39,13 @@ static class Diagnostics
         "Build",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    /// <summary>DCA005: Actor state types must be serializable.</summary>
+    public static DiagnosticDescriptor MustBeSerializable { get; } = new(
+        "DCA005",
+        "Actor state types must be serializable",
+        "Make '{0}' partial or add [GenerateSerializer] as required for types used in actor state.",
+        "Build",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/CloudActors.Abstractions.CodeAnalysis/TrackingNames.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/TrackingNames.cs
@@ -27,6 +27,7 @@ static class TrackingNames
 
     // ActorStateGenerator
     public const string StateModels = nameof(StateModels);
+    public const string StateSerializableTypes = nameof(StateSerializableTypes);
 
     // EventSourcedGenerator
     public const string EventSourcedModels = nameof(EventSourcedModels);

--- a/src/CloudActors.Abstractions.CodeFix/AddGenerateSerializerAttribute.cs
+++ b/src/CloudActors.Abstractions.CodeFix/AddGenerateSerializerAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Devlooped.CloudActors.CodeAnalysis;
+
+public class AddGenerateSerializerAttribute(Document document, SyntaxNode root, TypeDeclarationSyntax declaration) : CodeAction
+{
+    public override string Title => "Add [GenerateSerializer] attribute";
+    public override string EquivalenceKey => Title;
+
+    protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+    {
+        var attribute = Attribute(ParseName("Orleans.GenerateSerializer"));
+        var attributeList = AttributeList(SingletonSeparatedList(attribute));
+
+        var newDeclaration = declaration.AddAttributeLists(attributeList);
+        var newRoot = root.ReplaceNode(declaration, newDeclaration);
+
+        return Task.FromResult(document.WithSyntaxRoot(newRoot));
+    }
+}

--- a/src/CloudActors.Abstractions.CodeFix/TypeMustBeSerializable.cs
+++ b/src/CloudActors.Abstractions.CodeFix/TypeMustBeSerializable.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Devlooped.CloudActors.CodeAnalysis;
+
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public class TypeMustBeSerializable : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = [Diagnostics.MustBeSerializable.Id];
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root == null)
+            return;
+
+        var declaration = root.FindNode(context.Span).FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (declaration == null)
+            return;
+
+        context.RegisterCodeFix(
+            new AddPartialModifier(context.Document, root, declaration),
+            context.Diagnostics);
+
+        context.RegisterCodeFix(
+            new AddGenerateSerializerAttribute(context.Document, root, declaration),
+            context.Diagnostics);
+    }
+}

--- a/src/CloudActors.CodeAnalysis/ActorIdFactoryGenerator.cs
+++ b/src/CloudActors.CodeAnalysis/ActorIdFactoryGenerator.cs
@@ -57,11 +57,9 @@ class ActorIdFactoryGenerator : IIncrementalGenerator
             using Microsoft.Extensions.DependencyInjection;
             using Devlooped.CloudActors;
 
-            /// <summary>Extension methods for adding Cloud Actors services to the dependency injection container.</summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public static partial class CloudActorsGeneratedExtensions
+            internal static partial class CloudActorsGeneratedExtensions
             {
-                /// <summary>Adds the <see cref="IActorBus"/> service and actor activation logic.</summary>
                 public static IServiceCollection AddCloudActors(this IServiceCollection services)
                     => services.AddCloudActors(GeneratedActorIdFactory.Instance);               
             }

--- a/src/Tests.CodeFix/CodeFixers.cs
+++ b/src/Tests.CodeFix/CodeFixers.cs
@@ -207,4 +207,277 @@ public class CodeFixers
         await context.RunAsync();
     }
 
+    [Fact]
+    public async Task ReportNonSerializableStateType()
+    {
+        var context = new CSharpAnalyzerTest<ActorStateSerializableAnalyzer, DefaultVerifier>();
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([new PackageIdentity("Devlooped.CloudActors", "0.4.0")]);
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            public record {|DCA005:Transaction|}(string Type, decimal Amount, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public decimal Balance { get; private set; }
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
+    [Fact]
+    public async Task ReportNestedNonSerializableStateType()
+    {
+        var context = new CSharpAnalyzerTest<ActorStateSerializableAnalyzer, DefaultVerifier>();
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([new PackageIdentity("Devlooped.CloudActors", "0.4.0")]);
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            public record {|DCA005:Money|}(decimal Amount, string Currency);
+            public record {|DCA005:Transaction|}(string Type, Money Value, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
+    [Fact]
+    public async Task NoReportOnPartialStateType()
+    {
+        var context = new CSharpAnalyzerTest<ActorStateSerializableAnalyzer, DefaultVerifier>();
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([new PackageIdentity("Devlooped.CloudActors", "0.4.0")]);
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            public partial record Transaction(string Type, decimal Amount, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
+    [Fact]
+    public async Task NoReportOnGenerateSerializerStateType()
+    {
+        var context = new CSharpAnalyzerTest<ActorStateSerializableAnalyzer, DefaultVerifier>();
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([
+                new PackageIdentity("Devlooped.CloudActors", "0.4.0"),
+                new PackageIdentity("Microsoft.Orleans.Serialization.Abstractions", "8.2.0"),
+            ]);
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using Orleans;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            [GenerateSerializer]
+            public record Transaction(string Type, decimal Amount, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
+    [Fact]
+    public async Task NoReportOnPrimitiveAndSystemTypes()
+    {
+        var context = new CSharpAnalyzerTest<ActorStateSerializableAnalyzer, DefaultVerifier>();
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([new PackageIdentity("Devlooped.CloudActors", "0.4.0")]);
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            [Actor]
+            public partial class Account
+            {
+                public string Name { get; private set; }
+                public int Balance { get; private set; }
+                public decimal Amount { get; private set; }
+                public DateTimeOffset Created { get; private set; }
+                public List<string> Tags { get; private set; } = new();
+                public Dictionary<string, int> Metadata { get; private set; } = new();
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
+    [Fact]
+    public async Task NoReportOnEnum()
+    {
+        var context = new CSharpAnalyzerTest<ActorStateSerializableAnalyzer, DefaultVerifier>();
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([new PackageIdentity("Devlooped.CloudActors", "0.4.0")]);
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+
+            namespace Tests;
+
+            public enum AccountStatus { Active, Closed }
+
+            [Actor]
+            public partial class Account
+            {
+                public AccountStatus Status { get; private set; }
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixStateTypeAddPartial()
+    {
+        var context = new CSharpCodeFixTest<ActorStateSerializableAnalyzer, TypeMustBeSerializable, DefaultVerifier>();
+        context.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipLocalDiagnosticCheck;
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([new PackageIdentity("Devlooped.CloudActors", "0.4.0")]);
+        context.CodeActionIndex = 0; // First fix: Add partial modifier
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            public record {|DCA005:Transaction|}(string Type, decimal Amount, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        context.FixedCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            public partial record Transaction(string Type, decimal Amount, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixStateTypeAddGenerateSerializer()
+    {
+        var context = new CSharpCodeFixTest<ActorStateSerializableAnalyzer, TypeMustBeSerializable, DefaultVerifier>();
+        context.CodeFixTestBehaviors |= CodeFixTestBehaviors.SkipLocalDiagnosticCheck;
+        context.ReferenceAssemblies = ReferenceAssemblies.Net.Net80
+            .AddPackages([new PackageIdentity("Devlooped.CloudActors", "0.4.0")]);
+        context.CodeActionIndex = 1; // Second fix: Add [GenerateSerializer] attribute
+
+        context.TestCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            public record {|DCA005:Transaction|}(string Type, decimal Amount, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        context.FixedCode =
+            /* lang=c#-test */
+            """
+            using Devlooped.CloudActors;
+            using System;
+            using System.Collections.Generic;
+
+            namespace Tests;
+
+            [Orleans.GenerateSerializer]
+            public record Transaction(string Type, decimal Amount, DateTimeOffset Timestamp);
+
+            [Actor]
+            public partial class Wallet
+            {
+                public List<Transaction> Transactions { get; private set; } = new();
+            }
+            """;
+
+        await context.RunAsync();
+    }
+
 }


### PR DESCRIPTION
Implement comprehensive diagnostic (DCA005) that detects when actor state references user-defined types without [GenerateSerializer] attribute or partial modifier. This prevents silent Orleans serialization failures at runtime.

**New Components:**

1. ActorStateSerializableAnalyzer
   - Detects non-serializable types in actor state members
   - Uses RegisterCompilationStartAction + RegisterSyntaxNodeAction pattern
   - Ensures diagnostics appear in VS live analysis (4 iterations to perfect)
   - Reports on type declaration location (local to syntax tree)

2. DCA005 Diagnostic Descriptor
   - Error: 'Make {Type} partial or add [GenerateSerializer]'
   - Category: Build
   - Severity: Error

3. Type Walking Helpers (AnalysisExtensions)
   - IsUserDefinedSerializableCandidate: filters non-serializable types
   - WalkTypeForSerialization: recursively handles arrays, generics, nullable, and nested user-defined types
   - Cycle detection via HashSet<ITypeSymbol>
   - CollectStateSerializableTypes: deduplicates with message types
   - CollectMessageAdditionalTypes: prevents duplicate generation

4. Code Fix Provider (TypeMustBeSerializable)
   - Fix A: 'Add partial modifier' - makes type partial so generator adds [GenerateSerializer] in ActorStateGenerator pipeline
   - Fix B: 'Add [GenerateSerializer] attribute' - adds attribute directly
   - Two separate code actions via AddGenerateSerializerAttribute

5. Generator Extension (ActorStateGenerator)
   - Second pipeline for state-referenced types
   - Generates [GenerateSerializer] for partial types
   - Reuses SerializableGenerator.GenerateCode helper
   - Deduplicates with message-referenced types

**Key Design Decisions:**

- Recursive type detection handles nested user-defined types (e.g. Wallet → Transaction → Money)
- Only source-declared types are analyzed (external assemblies assumed ok)
- RegisterCompilationStartAction pre-computes types via Compilation.Assembly .GetAllTypes(), then RegisterSyntaxNodeAction reports locally per-document
- VS live analysis works because diagnostics are 'local' to target type's syntax tree (not 'non-local' cross-type diagnostics)

**Testing:**

- 8 new tests covering analyzer, both code fixes, and nested types
- Tests use CodeFixTestBehaviors.SkipLocalDiagnosticCheck for non-local diagnostics
- All 50 tests passing, no formatting issues

**Also Fixed:**

- CS0121 ambiguity in ActorIdFactoryGenerator: generated CloudActorsGeneratedExtensions now internal instead of public
- Prevents conflicts when multiple projects reference Devlooped.CloudActors
- [ModuleInitializer] still registers factory globally

**Updated Files:**

- src/CloudActors.Abstractions.CodeAnalysis/Diagnostics.cs: DCA005 descriptor
- src/CloudActors.Abstractions.CodeAnalysis/AnalysisExtensions.cs: type walking helpers
- src/CloudActors.Abstractions.CodeAnalysis/CacheableModels.cs: ActorModel with StateTypes field
- src/CloudActors.Abstractions.CodeAnalysis/ActorStateGenerator.cs: second pipeline for state type serialization
- src/CloudActors.Abstractions.CodeAnalysis/TrackingNames.cs: StateSerializableTypes
- src/CloudActors.Abstractions.CodeAnalysis/ActorStateSerializableAnalyzer.cs: new analyzer
- src/CloudActors.Abstractions.CodeFix/TypeMustBeSerializable.cs: new code fix provider
- src/CloudActors.Abstractions.CodeFix/AddGenerateSerializerAttribute.cs: new code action
- src/CloudActors.CodeAnalysis/ActorIdFactoryGenerator.cs: internal CloudActorsGeneratedExtensions
- src/Tests.CodeFix/CodeFixers.cs: 8 new tests
- AGENTS.md: DCA005 entry in diagnostics table

Fixes: DCA005 not detected, CS0121 ambiguity when multiple projects reference Devlooped.CloudActors