### PR TITLE
Update NuGetizer to 1.4.7 and minor msbuildproj cleanup

### DIFF
--- a/src/CloudActors.Abstractions.CodeAnalysis/CloudActors.Abstractions.CodeAnalysis.csproj
+++ b/src/CloudActors.Abstractions.CodeAnalysis/CloudActors.Abstractions.CodeAnalysis.csproj
@@ -22,7 +22,7 @@
     <!-- See: https://github.com/NuGet/Home/issues/6279. For now, ExcludeAssets doesn't work for analyzers/generators, so we ARE running 
          the Orleans source generator in this analyzer project itself, even if we don't want/need to. -->
     <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="$(OrleansVersion)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" Version="4.8.0" />
     <PackageReference Include="PolySharp" PrivateAssets="All" Version="1.15.0" />
 

--- a/src/CloudActors.Abstractions.CodeFix/CloudActors.Abstractions.CodeFix.csproj
+++ b/src/CloudActors.Abstractions.CodeFix/CloudActors.Abstractions.CodeFix.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Pack="false" Version="4.8.0" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" PrivateAssets="all" />

--- a/src/CloudActors.Abstractions.Package/CloudActors.Abstractions.Package.msbuildproj
+++ b/src/CloudActors.Abstractions.Package/CloudActors.Abstractions.Package.msbuildproj
@@ -10,7 +10,7 @@
     <PackNone>true</PackNone>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CloudActors.Abstractions.CodeAnalysis\CloudActors.Abstractions.CodeAnalysis.csproj" />

--- a/src/CloudActors.Abstractions/CloudActors.Abstractions.csproj
+++ b/src/CloudActors.Abstractions/CloudActors.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Serialization.Abstractions" Version="$(OrleansVersion)" />
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
     <PackageReference Include="PolySharp" PrivateAssets="All" Version="1.15.0" />
   </ItemGroup>
 

--- a/src/CloudActors.Hosting/CloudActors.Hosting.csproj
+++ b/src/CloudActors.Hosting/CloudActors.Hosting.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
     <PackageReference Include="Microsoft.Orleans.Server" Version="$(OrleansVersion)" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.1.2" PrivateAssets="all" />
   </ItemGroup>

--- a/src/CloudActors.Package/CloudActors.Package.msbuildproj
+++ b/src/CloudActors.Package/CloudActors.Package.msbuildproj
@@ -10,7 +10,7 @@
     <PackNone>true</PackNone>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CloudActors.Abstractions.Package\CloudActors.Abstractions.Package.msbuildproj" />

--- a/src/CloudActors.Streamstone/CloudActors.Streamstone.csproj
+++ b/src/CloudActors.Streamstone/CloudActors.Streamstone.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Devlooped.CloudStorageAccount" Version="1.4.0" />
     <PackageReference Include="Microsoft.Orleans.Runtime" Version="$(OrleansVersion)" />
-    <PackageReference Include="NuGetizer" Version="1.4.6" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
     <PackageReference Include="Streamstone" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated NuGetizer package references to 1.4.7 across all projects for consistency. Adjusted <PackageLicenseExpression> formatting in package msbuildproj files and fixed closing </Project> tag placement.