### PR TITLE
Avoid error during dotnet format from improper analyzer

### DIFF
--- a/src/CloudActors.Abstractions.CodeAnalysis/CloudActors.Abstractions.CodeAnalysis.csproj
+++ b/src/CloudActors.Abstractions.CodeAnalysis/CloudActors.Abstractions.CodeAnalysis.csproj
@@ -38,6 +38,14 @@
     <Reference Include="$(PkgMicrosoft_Orleans_CodeGenerator)\analyzers\dotnet\cs\Orleans.CodeGenerator.dll" />
   </ItemGroup>
 
+  <!-- NuGet issue https://github.com/NuGet/Home/issues/6279: ExcludeAssets="all" doesn't prevent analyzer registration.
+       Explicitly remove the Orleans generator so it doesn't run (and crash) in this project. -->
+  <Target Name="RemoveOrleansGeneratorFromAnalyzers" AfterTargets="ResolvePackageDependenciesForBuild">
+    <ItemGroup>
+      <Analyzer Remove="$(PkgMicrosoft_Orleans_CodeGenerator)\analyzers\dotnet\cs\Orleans.CodeGenerator.dll" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <EmbeddedResource Include="@(None -&gt; WithMetadataValue('Extension', '.sbntxt'))" Kind="text" />
   </ItemGroup>

--- a/src/CloudActors.Hosting.CodeAnalysis/CloudActors.Hosting.CodeAnalysis.csproj
+++ b/src/CloudActors.Hosting.CodeAnalysis/CloudActors.Hosting.CodeAnalysis.csproj
@@ -40,6 +40,14 @@
     <Reference Include="$(PkgMicrosoft_Orleans_CodeGenerator)\analyzers\dotnet\cs\Orleans.CodeGenerator.dll" />
   </ItemGroup>
 
+  <!-- NuGet issue https://github.com/NuGet/Home/issues/6279: ExcludeAssets="all" doesn't prevent analyzer registration.
+       Explicitly remove the Orleans generator so it doesn't run (and crash) in this project. -->
+  <Target Name="RemoveOrleansGeneratorFromAnalyzers" AfterTargets="ResolvePackageDependenciesForBuild">
+    <ItemGroup>
+      <Analyzer Remove="$(PkgMicrosoft_Orleans_CodeGenerator)\analyzers\dotnet\cs\Orleans.CodeGenerator.dll" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <EmbeddedResource Include="@(None -&gt; WithMetadataValue('Extension', '.sbntxt'))" Kind="text" />
     <None Update="Devlooped.CloudActors.targets" PackFolder="build" />


### PR DESCRIPTION
We use the Orleans Generator as an API, not as analyzer, so we explicitly exclude them to sidestep nuget issue.