### PR TITLE
Enable STJ source-gen for actor state/event serialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,10 @@ Template: `EventSourced.sbntxt`
 
 Helper that wraps the Orleans Roslyn source generator (`Microsoft.Orleans.CodeGenerator`) to produce the `.orleans.cs` file from generated code. Uses `CodeGeneratorOptions` with `GenerateFieldIds` and `GenerateCompatibilityInvokers` sourced from MSBuild properties.
 
+### JsonContextGenerator
+
+Helper that discovers and invokes the STJ (`System.Text.Json`) source generator via reflection at build time. Uses `AppDomain.CurrentDomain.GetAssemblies()` to find `System.Text.Json.SourceGeneration.JsonSourceGenerator`, creates an instance, and runs it via `CSharpGeneratorDriver`. The generated `ActorJsonContext` (nested in `ActorState`) gets its abstract members implemented by the STJ gen output. Falls back gracefully (no `ActorJsonContext` emitted) if the STJ gen is unavailable.
+
 ---
 
 ## Typed Actor IDs
@@ -269,6 +273,7 @@ An optional event-store-aware `IGrainStorage` implementation backed by [Streamst
 - For regular actors: state is stored as a single JSON entity
 - **Auto-snapshot**: when `StreamstoneOptions.AutoSnapshot = true`, each write also atomically upserts a `"State"` row with the serialized current state. On load, if the snapshot is version-compatible with the assembly, it is used directly (no event replay needed)
 - **Version compatibility**: controlled by `SnapshotVersionCompatibility` (Major or Minor)
+- **STJ source-generated serialization**: The generated `ActorState` class includes a nested `ActorJsonContext : JsonSerializerContext` with `[JsonSerializable]` attributes for the state type, custom state member types, and event types. `StreamstoneStorage` resolves JSON options via `IActorState.JsonOptions`, falling back to `StreamstoneOptions.JsonOptions` when unavailable. The STJ source generator is invoked programmatically at build time via reflection (discovered from loaded build-time assemblies via `StjGenerator.cs`).
 - Register via extension methods on `ISiloBuilder`:
   - `AddStreamstoneActorStorageAsDefault()` — registers as the default grain storage provider
   - `AddStreamstoneActorStorageAsDefault(Action<StreamstoneOptions> configure)` — with configuration

--- a/src/CloudActors.Abstractions.CodeAnalysis/ActorState.sbntxt
+++ b/src/CloudActors.Abstractions.CodeAnalysis/ActorState.sbntxt
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.CodeDom.Compiler;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Orleans;
 using Devlooped.CloudActors;
 
@@ -48,6 +50,25 @@ partial class {{ Name }} : IActor<{{ Name }}.ActorState>
         {{~ for member in Members ~}}
         [Id({{ ++index }})]
         public {{ member.Type }} {{ member.Name }};
+        {{~ end ~}}
+
+        {{~ if HasJsonContext ~}}
+        JsonSerializerOptions? IActorState.JsonOptions => ActorJsonContext.Default.Options;
+
+        [JsonSourceGenerationOptions(
+            AllowTrailingCommas = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            IncludeFields = true,
+            PreferredObjectCreationHandling = JsonObjectCreationHandling.Populate,
+            UseStringEnumConverter = true)]
+        [JsonSerializable(typeof(ActorState))]
+        {{~ for stype in StateTypes ~}}
+        [JsonSerializable(typeof({{ stype.Type }}))]
+        {{~ end ~}}
+        {{~ for etype in EventTypes ~}}
+        [JsonSerializable(typeof({{ etype }}))]
+        {{~ end ~}}
+        partial class ActorJsonContext : JsonSerializerContext { }
         {{~ end ~}}
     }
 

--- a/src/CloudActors.Abstractions.CodeAnalysis/ActorStateGenerator.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/ActorStateGenerator.cs
@@ -46,23 +46,75 @@ class ActorStateGenerator : IIncrementalGenerator
             .Select(static (x, _) => x!.Value)
             .WithTrackingName(TrackingNames.StateModels);
 
-        context.RegisterImplementationSourceOutput(actors, (ctx, actor) =>
+        // Use RegisterSourceOutput (not Implementation) so the STJ source generator
+        // can see the generated ActorJsonContext and produce its serializer implementation.
+        context.RegisterSourceOutput(
+            actors.Combine(context.CompilationProvider).Combine(context.ParseOptionsProvider),
+            (ctx, source) =>
         {
+            var ((actor, compilation), parseOptions) = source;
+
             var members = actor.Properties.AsImmutableArray()
                 .AddRange(actor.Fields.AsImmutableArray())
                 .Select(m => new { m.Name, m.Type })
                 .ToArray();
 
+            var stateTypes = actor.StateTypes.AsImmutableArray()
+                .Select(t => new { t.Name, Type = t.FullName })
+                .ToArray();
+
+            var eventTypes = actor.EventTypes.AsImmutableArray().ToArray();
+
+            // First render with HasJsonContext = true to attempt STJ gen
+            var hasJsonContext = JsonContextGenerator.IsAvailable;
             var model = new
             {
                 actor.Namespace,
                 actor.Name,
                 Members = members,
-                actor.IsEventSourced,
+                StateTypes = stateTypes,
+                EventTypes = eventTypes,
+                EventSourced = actor.IsEventSourced,
+                HasJsonContext = hasJsonContext,
                 Version = ThisAssembly.Info.InformationalVersion
             };
 
             var output = template.Render(model, member => member.Name);
+
+            if (hasJsonContext)
+            {
+                var stjResults = JsonContextGenerator.GenerateCode(
+                    compilation,
+                    parseOptions as CSharpParseOptions,
+                    output,
+                    "ActorJsonContext",
+                    ctx.CancellationToken);
+
+                if (stjResults.Length > 0)
+                {
+                    ctx.AddSource($"{actor.FileName}.State.cs", output);
+                    foreach (var (hintName, stjSource) in stjResults)
+                    {
+                        ctx.AddSource($"{actor.FileName}.{hintName}", stjSource);
+                    }
+                    return;
+                }
+
+                // STJ gen failed, re-render without JSON context
+                model = new
+                {
+                    actor.Namespace,
+                    actor.Name,
+                    Members = members,
+                    StateTypes = stateTypes,
+                    EventTypes = eventTypes,
+                    EventSourced = actor.IsEventSourced,
+                    HasJsonContext = false,
+                    Version = ThisAssembly.Info.InformationalVersion
+                };
+                output = template.Render(model, member => member.Name);
+            }
+
             ctx.AddSource($"{actor.FileName}.State.cs", output);
         });
 

--- a/src/CloudActors.Abstractions.CodeAnalysis/AnalysisExtensions.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/AnalysisExtensions.cs
@@ -172,7 +172,7 @@ static class AnalysisExtensions
         var messageAdditionalTypes = CollectMessageAdditionalTypes(compilation);
 
         // Only return partial, non-actor, non-message types not already covered by message generation
-        return candidates
+        return [.. candidates
             .Where(t => t.IsPartial() && !t.IsActorMessage() && !t.IsActor() &&
                 !messageAdditionalTypes.Contains(t))
             .Select(t => new SerializableTypeModel(
@@ -180,8 +180,7 @@ static class AnalysisExtensions
                 t.ContainingNamespace.IsGlobalNamespace ? "" : t.ContainingNamespace.ToDisplayString(),
                 t.ToDisplayString(FullName),
                 t.IsRecord))
-            .Distinct()
-            .ToImmutableArray();
+            .Distinct()];
     }
 
     /// <summary>

--- a/src/CloudActors.Abstractions.CodeAnalysis/CacheableModels.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/CacheableModels.cs
@@ -38,14 +38,16 @@ record struct ActorModel(
     /// <summary>Whether the Guid type has CreateVersion7 method (for primitive Guid IDs).</summary>
     bool HasGuidCreateVersion7,
     /// <summary>Partial user-defined types referenced from actor state that need [GenerateSerializer].</summary>
-    EquatableArray<SerializableTypeModel> StateTypes) : IEquatable<ActorModel>
+    EquatableArray<SerializableTypeModel> StateTypes,
+    /// <summary>Event type names for event-sourced actors (for [JsonSerializable] generation).</summary>
+    EquatableArray<string> EventTypes) : IEquatable<ActorModel>
 {
     public string FileName => FullName.Replace('+', '.');
 }
 
 record struct ActorMemberModel(string Name, string TypeName) : IEquatable<ActorMemberModel>
 {
-    public string Type => TypeName switch
+    public readonly string Type => TypeName switch
     {
         "System.String" => "string",
         "System.Int32" => "int",
@@ -92,7 +94,7 @@ record struct SerializableTypeModel(
     string FullName,
     bool IsRecord) : IEquatable<SerializableTypeModel>
 {
-    public string FileName => FullName.Replace('+', '.');
+    public readonly string FileName => FullName.Replace('+', '.');
 }
 
 /// <summary>
@@ -109,7 +111,7 @@ record struct ActorMessageModel(
     string? ReturnTypeFullName,
     EquatableArray<SerializableTypeModel> AdditionalTypes) : IEquatable<ActorMessageModel>
 {
-    public string FileName => FullName.Replace('+', '.');
+    public readonly string FileName => FullName.Replace('+', '.');
 }
 
 // ──────────────────────────────────────────────
@@ -226,6 +228,15 @@ static class ModelExtractors
             ? AnalysisExtensions.CollectStateSerializableTypes(actor, ns, compilation)
             : ImmutableArray<SerializableTypeModel>.Empty;
 
+        // Collect event types from partial void Apply(EventType) methods
+        var eventTypes = isEventSourced
+            ? [.. actor.GetMembers()
+                .OfType<IMethodSymbol>()
+                .Where(m => m.Name == "Apply" && m.ReturnsVoid && m.Parameters.Length == 1 && !m.IsAbstract)
+                .Select(m => m.Parameters[0].Type.ToDisplayString(FullName))
+                .Distinct()]
+            : ImmutableArray<string>.Empty;
+
         return new ActorModel(
             Name: actor.Name,
             Namespace: ns,
@@ -243,7 +254,8 @@ static class ModelExtractors
             IsPrimitiveId: isPrimitiveId,
             IsTypedId: isTypedId,
             HasGuidCreateVersion7: hasGuidCreateVersion7,
-            StateTypes: stateTypes);
+            StateTypes: stateTypes,
+            EventTypes: eventTypes);
     }
 
     static (string? IdTypeFullName, bool IsPrimitive, bool IsTypedId) ExtractIdInfo(
@@ -416,6 +428,6 @@ static class ModelExtractors
                 }
             }
         }
-        return events.ToImmutableArray();
+        return [.. events];
     }
 }

--- a/src/CloudActors.Abstractions.CodeAnalysis/JsonContextGenerator.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/JsonContextGenerator.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Devlooped.CloudActors;
+
+/// <summary>
+/// Invokes the STJ (System.Text.Json) source generator via reflection to produce 
+/// serializer implementations for generated <c>JsonSerializerContext</c> types.
+/// Discovers the STJ generator from assemblies loaded in the current build context.
+/// </summary>
+static class JsonContextGenerator
+{
+    static readonly Lazy<Type?> generatorType = new(FindGeneratorType);
+
+    /// <summary>
+    /// Whether the STJ source generator is available in the current build context.
+    /// </summary>
+    public static bool IsAvailable => generatorType.Value != null;
+
+    /// <summary>
+    /// Runs the STJ source generator on the provided context source code, returning 
+    /// the generated serializer implementation files.
+    /// </summary>
+    /// <returns>
+    /// Generated source files filtered to those matching <paramref name="contextClassName"/>. 
+    /// Empty if the STJ generator is not available or fails.
+    /// </returns>
+    public static ImmutableArray<(string HintName, string Source)> GenerateCode(
+        Compilation compilation,
+        CSharpParseOptions? parseOptions,
+        string contextSource,
+        string contextClassName,
+        CancellationToken cancellation = default)
+    {
+        var type = generatorType.Value;
+        if (type == null)
+            return [];
+
+        try
+        {
+            if (Activator.CreateInstance(type) is not IIncrementalGenerator generator)
+                return [];
+
+            var tree = CSharpSyntaxTree.ParseText(contextSource, parseOptions);
+            compilation = compilation.AddSyntaxTrees(tree);
+
+            var driver = CSharpGeneratorDriver.Create(
+                generators: [generator.AsSourceGenerator()],
+                parseOptions: parseOptions ?? CSharpParseOptions.Default);
+
+            driver = (CSharpGeneratorDriver)driver.RunGenerators(compilation, cancellation);
+            var result = driver.GetRunResult();
+
+            if (result.Results.Length == 0)
+                return [];
+
+            // Only return output related to our context, not any user-defined contexts
+            return [.. result.Results[0].GeneratedSources
+                .Where(g => g.HintName.Contains(contextClassName))
+                .Select(g => (g.HintName, g.SourceText.ToString()))];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    static Type? FindGeneratorType()
+    {
+        try
+        {
+            var asm = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "System.Text.Json.SourceGeneration");
+
+            return asm?.GetType("System.Text.Json.SourceGeneration.JsonSourceGenerator");
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/CloudActors.Abstractions/IActorState.cs
+++ b/src/CloudActors.Abstractions/IActorState.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Text.Json;
 
 namespace Devlooped.CloudActors;
 
@@ -6,7 +7,14 @@ namespace Devlooped.CloudActors;
 /// Marker interface for actor state.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IActorState { }
+public interface IActorState
+{
+    /// <summary>
+    /// Gets the source-generated <see cref="JsonSerializerOptions"/> for this state type, 
+    /// or <see langword="null"/> to use the default options from the storage provider.
+    /// </summary>
+    JsonSerializerOptions? JsonOptions => null;
+}
 
 /// <summary>
 /// Generic version of the marker interface for state so we can track back its owning actor type.

--- a/src/CloudActors.Streamstone/StreamstoneStorage.cs
+++ b/src/CloudActors.Streamstone/StreamstoneStorage.cs
@@ -41,6 +41,7 @@ public class StreamstoneStorage : IGrainStorage
     {
         var table = await GetTable(storage, stateName);
         var rowId = grainId.Key.ToString();
+        var jsonOptions = GetJsonOptions(grainState);
 
         if (grainState.State is IEventSourced state)
         {
@@ -60,7 +61,7 @@ public class StreamstoneStorage : IGrainStorage
                     typeof(T).Assembly.GetName() is { } asm &&
                     IsCompatible(new Version(asm.Version?.Major ?? 0, asm.Version?.Minor ?? 0), entity.DataVersion) &&
                     entity.Data is string data &&
-                    JsonSerializer.Deserialize<T>(data, options.JsonOptions) is { } instance)
+                    JsonSerializer.Deserialize<T>(data, jsonOptions) is { } instance)
                 {
                     // Since auto-snapshotting is performed automatically and atomically on 
                     // every write, we don't need to replay any further events.
@@ -76,7 +77,7 @@ public class StreamstoneStorage : IGrainStorage
                 return;
 
             // TODO: should we always re-create the state instance?
-            state.LoadEvents(entities.Events.Select(ToDomainEvent));
+            state.LoadEvents(entities.Events.Select(e => ToDomainEvent(e, jsonOptions)));
             grainState.ETag = stream.Stream.Version.ToString();
             grainState.RecordExists = true;
         }
@@ -87,7 +88,7 @@ public class StreamstoneStorage : IGrainStorage
                 result.Value is not EventEntity entity ||
                 entity.Data is not string data ||
                 // TODO: how to deal with versioning in this case?
-                JsonSerializer.Deserialize<T>(data, options.JsonOptions) is not { } instance)
+                JsonSerializer.Deserialize<T>(data, jsonOptions) is not { } instance)
                 return;
 
             grainState.State = instance;
@@ -103,6 +104,7 @@ public class StreamstoneStorage : IGrainStorage
         var rowId = grainId.Key.ToString();
         var type = typeof(T);
         var asm = typeof(T).Assembly.GetName();
+        var jsonOptions = GetJsonOptions(grainState);
 
         if (grainState.State is IEventSourced state)
         {
@@ -124,7 +126,7 @@ public class StreamstoneStorage : IGrainStorage
                         {
                             PartitionKey = table.Name,
                             RowKey = "State",
-                            Data = JsonSerializer.Serialize(grainState.State, options.JsonOptions),
+                            Data = JsonSerializer.Serialize(grainState.State, jsonOptions),
                             DataVersion = new Version(asm.Version?.Major ?? 0, asm.Version?.Minor ?? 0).ToString(),
                             Type = $"{type.FullName ?? typeof(T).Name}, {asm.Name}",
                             Version = stream.Version + state.Events.Count
@@ -133,7 +135,7 @@ public class StreamstoneStorage : IGrainStorage
 
                 await Stream.WriteAsync(partition,
                     int.TryParse(grainState.ETag, out var version) ? version : 0,
-                    [.. state.Events.Select((e, i) => ToEventData(e, stream.Version + i, includes))]);
+                    [.. state.Events.Select((e, i) => ToEventData(e, stream.Version + i, jsonOptions, includes))]);
 
                 grainState.ETag = (stream.Version + state.Events.Count).ToString();
                 grainState.RecordExists = true;
@@ -151,7 +153,7 @@ public class StreamstoneStorage : IGrainStorage
                 PartitionKey = table.Name,
                 RowKey = rowId!,
                 ETag = new ETag(grainState.ETag),
-                Data = JsonSerializer.Serialize(grainState.State, options.JsonOptions),
+                Data = JsonSerializer.Serialize(grainState.State, jsonOptions),
                 DataVersion = new Version(asm.Version?.Major ?? 0, asm.Version?.Minor ?? 0).ToString(),
                 Type = $"{type.FullName}, {asm.Name}",
             })]);
@@ -160,6 +162,9 @@ public class StreamstoneStorage : IGrainStorage
             grainState.RecordExists = true;
         }
     }
+
+    JsonSerializerOptions GetJsonOptions<T>(IGrainState<T> grainState)
+        => (grainState.State as IActorState)?.JsonOptions ?? options.JsonOptions;
 
     async Task<TableClient> GetTable(CloudStorageAccount storage, string name)
     {
@@ -200,7 +205,7 @@ public class StreamstoneStorage : IGrainStorage
         public int? Version { get; set; }
     }
 
-    object ToDomainEvent(EventEntity entity)
+    static object ToDomainEvent(EventEntity entity, JsonSerializerOptions jsonOptions)
     {
         if (entity.Data == null)
             throw new InvalidOperationException();
@@ -209,10 +214,10 @@ public class StreamstoneStorage : IGrainStorage
 
         // TODO: handle version mismatch between type and entity.DataVersion
 
-        return JsonSerializer.Deserialize(entity.Data, type, options.JsonOptions)!;
+        return JsonSerializer.Deserialize(entity.Data, type, jsonOptions)!;
     }
 
-    EventData ToEventData(object e, int version, params ITableEntity[] includes)
+    static EventData ToEventData(object e, int version, JsonSerializerOptions jsonOptions, params ITableEntity[] includes)
     {
         var type = e.GetType();
         var asm = type.Assembly.GetName();
@@ -220,7 +225,7 @@ public class StreamstoneStorage : IGrainStorage
         // convenient for quickly glancing at the data.
         var properties = new
         {
-            Data = JsonSerializer.Serialize(e, options.JsonOptions),
+            Data = JsonSerializer.Serialize(e, jsonOptions),
             DataVersion = new Version(asm.Version?.Major ?? 0, asm.Version?.Minor ?? 0).ToString(),
             // Visualizing the event id in the table as a column is useful for querying
             Type = $"{e.GetType().FullName}, {e.GetType().Assembly.GetName().Name}",

--- a/src/Tests/StreamstoneTests.cs
+++ b/src/Tests/StreamstoneTests.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using Devlooped;
 using Devlooped.CloudActors;
 using Orleans;
@@ -57,6 +60,91 @@ public class StreamstoneTests
         actor.SetState(state.State);
 
         Assert.Equal(wallet.Funds, state.State.Funds);
+    }
+    [Fact]
+    public async Task GeneratedJsonContextIsUsedForSerialization()
+    {
+        // Custom options clearly differ from the generated ActorJsonContext defaults:
+        // - camelCase naming  (generated ActorJsonContext uses PascalCase, the STJ default)
+        // - no string enum converter  (generated uses UseStringEnumConverter = true)
+        // If StreamstoneStorage uses the state's IActorState.JsonOptions (i.e. the generated
+        // ActorJsonContext), the raw JSON in the table must still be PascalCase with string enums.
+        var customOptions = new StreamstoneOptions
+        {
+            AutoSnapshot = false,
+            JsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                // No JsonStringEnumConverter → enums serialized as numbers
+            }
+        };
+        var storage = new StreamstoneStorage(CloudStorageAccount.DevelopmentStorageAccount, customOptions);
+
+        // --- Non-event-sourced actor: Wallet ---
+        const string walletTable = "CloudActorWallet";
+        await CloudStorageAccount.DevelopmentStorageAccount
+            .CreateCloudTableClient()
+            .DeleteTableAsync(walletTable);
+
+        var wallet = new Wallet("json-ctx-test");
+        wallet.AddFunds("USD", 100m);
+        wallet.AddFunds("EUR", 50m);
+
+        var walletActor = (IActor<Wallet.ActorState>)wallet;
+        await storage.WriteStateAsync(walletTable, GrainId.Parse("wallet/json-ctx-test"),
+            GrainState.Create(walletActor.GetState()));
+
+        // Use QueryAsync (not GetEntityAsync) – '/' in row keys is disallowed in path-based
+        // Azure Table REST calls, but OData filter expressions handle them fine.
+        var walletJson = default(string);
+        await foreach (var entity in CloudStorageAccount.DevelopmentStorageAccount
+            .CreateCloudTableClient()
+            .GetTableClient(walletTable)
+            .QueryAsync<TableEntity>(e => e.PartitionKey == walletTable))
+        {
+            walletJson = entity.GetString("Data");
+            if (walletJson is not null) break;
+        }
+
+        Assert.NotNull(walletJson);
+        // Generated context: PascalCase → "Funds", not "funds"
+        Assert.Contains("\"Funds\"", walletJson);
+
+        // --- Event-sourced actor: Account (Closed event has Balance + CloseReason enum) ---
+        const string accountTable = nameof(Account);
+        await CloudStorageAccount.DevelopmentStorageAccount
+            .CreateCloudTableClient()
+            .DeleteTableAsync(accountTable);
+
+        var account = new Account("json-ctx-test");
+        account.Deposit(new Deposit(100));
+        account.Close(new Close(CloseReason.Fraud));
+
+        var accountActor = (IActor<Account.ActorState>)account;
+        await storage.WriteStateAsync(accountTable, GrainId.Parse("account/json-ctx-test"),
+            GrainState.Create(accountActor.GetState()));
+
+        // Read all event entities in the stream partition (PK = grain key, without type prefix)
+        var accountEvents = CloudStorageAccount.DevelopmentStorageAccount
+            .CreateCloudTableClient()
+            .GetTableClient(accountTable)
+            .QueryAsync<TableEntity>(filter: string.Empty);
+
+        var dataValues = new List<string>();
+        await foreach (var entity in accountEvents)
+        {
+            if (entity.TryGetValue("Data", out var raw) && raw is string json)
+                dataValues.Add(json);
+        }
+
+        Assert.NotEmpty(dataValues);
+
+        // Generated context: PascalCase → "Amount"/"Balance"/"Reason", not camelCase
+        // Generated context: string enum → "Fraud", not 1 (numeric value of CloseReason.Fraud)
+        Assert.Contains(dataValues, j => j.Contains("\"Amount\""));      // Deposited event
+        Assert.Contains(dataValues, j => j.Contains("\"Reason\""));      // Closed event: PascalCase
+        Assert.Contains(dataValues, j => j.Contains("\"Fraud\""));       // Closed event: string enum
+        Assert.DoesNotContain(dataValues, j => j.Contains("\"reason\"")); // Not camelCase
     }
 }
 

--- a/src/cecil.cs
+++ b/src/cecil.cs
@@ -4,30 +4,62 @@
 #:property PublishAot=false
 #:property IsPackable=false
 
+using System.Linq;
 using Mono.Cecil;
 
 if (args.Length < 2)
 {
     Console.WriteLine("Usage: cecil <assemblyPath> <typeFullName>");
+    Console.WriteLine("       cecil <assemblyPath> --strip-attribute <typeFullName> <attributeName>");
     return -1;
 }
 
-var (assemblyPath, typeName) = (args[0], args[1]);
-using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
+var assemblyPath = args[0];
+using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters { ReadWrite = true });
 
-var typeToRemove = assembly.MainModule.GetType(typeName);
-if (typeToRemove != null)
+if (args.Length >= 4 && args[1] == "--strip-attribute")
 {
-    assembly.MainModule.Types.Remove(typeToRemove);
-    string tempPath = Path.GetTempFileName();
-    assembly.Write(tempPath);
-    assembly.Dispose();
-    File.Move(tempPath, assemblyPath, true);
-    Console.WriteLine($"Removed type '{typeName}' from {assemblyPath}.");
+    var typeName = args[2];
+    var attrName = args[3];
+    var type = assembly.MainModule.GetType(typeName);
+    if (type == null)
+    {
+        Console.WriteLine($"Type '{typeName}' not found in '{assemblyPath}'.");
+        return 1;
+    }
+
+    var attr = type.CustomAttributes.FirstOrDefault(a => a.AttributeType.Name == attrName || a.AttributeType.FullName == attrName);
+    if (attr != null)
+    {
+        type.CustomAttributes.Remove(attr);
+        string tempPath = Path.GetTempFileName();
+        assembly.Write(tempPath);
+        assembly.Dispose();
+        File.Move(tempPath, assemblyPath, true);
+        Console.WriteLine($"Removed [{attrName}] from '{typeName}' in {assemblyPath}.");
+    }
+    else
+    {
+        Console.WriteLine($"Attribute '{attrName}' not found on type '{typeName}'.");
+    }
 }
 else
 {
-    Console.WriteLine($"Type '{typeName}' not found in '{assemblyPath}'.");
+    var typeName = args[1];
+    var typeToRemove = assembly.MainModule.GetType(typeName);
+    if (typeToRemove != null)
+    {
+        assembly.MainModule.Types.Remove(typeToRemove);
+        string tempPath = Path.GetTempFileName();
+        assembly.Write(tempPath);
+        assembly.Dispose();
+        File.Move(tempPath, assemblyPath, true);
+        Console.WriteLine($"Removed type '{typeName}' from {assemblyPath}.");
+    }
+    else
+    {
+        Console.WriteLine($"Type '{typeName}' not found in '{assemblyPath}'.");
+    }
 }
 
 return 0;


### PR DESCRIPTION
Adds JsonContextGenerator to invoke System.Text.Json source generator at build time for actor state and event types. Updates ActorState codegen to emit a nested ActorJsonContext and implement IActorState.JsonOptions. StreamstoneStorage now uses the generated context for serialization/deserialization. Refactors serialization paths to pass JsonSerializerOptions. Updates docs and tests to verify correct context usage. Enhances cecil.cs to strip specific attributes from types.

Fixes #138