### PR TITLE
Implement background save functionality and event confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,14 +79,15 @@ Actor messages should be `partial record` types (required for source generators 
 `JournaledAttribute` is an opt-in for event-sourced actors that should generate a `JournaledGrain<TView, TEvent>` wrapper instead of the default snapshot-backed grain.
 
 - Requires the actor to also be `[Actor]` and list `IEventSourced`
-- `Backend` can target `CustomStorage` (default), `StateStorage`, or `LogStorage`
 - `ProviderName` overrides the Orleans log consistency/storage provider name when needed
+- `BackgroundSave` switches journaled actors from the default auto-`await ConfirmEvents()` behavior to manual confirmation mode (`[Journaled(backgroundSave: true)]`)
 
 ### IEventSourced
 
 Interface implemented by actors that use event sourcing. The implementation is **code-generated**; actors only need to list it in the base type list without implementing it. The generator provides:
 - `Raise<T>(event)` — records an event and calls the matching `partial void Apply(TEvent)` method
 - `Events`, `AcceptEvents()`, `LoadEvents()` — managed by the storage provider
+- `ConfirmEvents()` — a generated protected helper available on every event-sourced actor. It is a safe no-op unless the hosting runtime/provider wires a confirmation callback.
 
 ### IActorIdFactory
 
@@ -204,7 +205,8 @@ For each actor, generates:
 For `[Journaled]` actors, the generator instead emits a `JournaledGrain<ActorState, object>` wrapper that:
 - uses `ActorState` as the Orleans `TView`
 - instantiates a transient POCO actor from the current view for commands and queries
-- collects actor-raised events, forwards them through `RaiseEvents(...)`, and calls `ConfirmEvents()`
+- wires generated `IConfirmableEvents.ConfirmEventsCallback` on the actor so `await ConfirmEvents()` can be used inside actor code
+- forwards actor-raised events through `RaiseEvents(...)` and, unless `[Journaled(backgroundSave: true)]` is set, auto-awaits `ConfirmEvents()` at the end of the command
 - replays journaled events in `TransitionState` by rehydrating a transient actor and copying its updated state back to `ActorState`
 
 Template: `StandardGrain.sbntxt`
@@ -306,6 +308,7 @@ An optional event-store-aware `IGrainStorage` implementation backed by [Streamst
 - **Auto-snapshot**: when `StreamstoneOptions.AutoSnapshot = true`, each write also atomically upserts a `"State"` row with the serialized current state. On load, if the snapshot is version-compatible with the assembly, it is used directly (no event replay needed)
 - **Version compatibility**: controlled by `SnapshotVersionCompatibility` (Major or Minor)
 - **Background save** (`StreamstoneOptions.BackgroundSave`, default `false`): when enabled, `WriteStateAsync` for `IEventSourced` actors is fire-and-forget. Events are snapshotted and `AcceptEvents()` is called synchronously on the grain scheduler; the actual `Stream.WriteAsync` is performed by a per-grain `BatchWorker` (ported from Orleans' `JournaledGrain`/`PrimaryBasedLogViewAdaptor` in `BatchWorker.cs`). Bursts of writes coalesce into a single Streamstone batch (one snapshot row per batch). Knobs: `BackgroundSaveMaxAttempts` (default `5`) and `BackgroundSaveRetryDelay` (default `200ms`, capped exponential backoff). On terminal failure the worker logs and force-deactivates the grain via `IGrainContext.Deactivate` (resolved through `IGrainContextAccessor`); next activation rebuilds from durable storage. Non-event-sourced actors keep the synchronous behavior even when the option is on. Use `StreamstoneStorage.FlushAsync(stateName, grainId)` to await durability from tests or grain code; the worker also auto-flushes on grain deactivation via `IGrainContext.ObservableLifecycle`.
+- **Actor-level confirmation bridge**: every generated `IEventSourced` actor now implements a public-but-hidden `IConfirmableEvents` interface. Standard snapshot-backed actors use it as a no-op unless a provider wires it; Streamstone wires it to `FlushAsync(...)` when `BackgroundSave` is enabled.
 - **STJ source-generated serialization**: The generated `ActorState` class includes a nested `ActorJsonContext : JsonSerializerContext` with `[JsonSerializable]` attributes for the state type, custom state member types, and event types. `StreamstoneStorage` resolves JSON options via `IActorState.JsonOptions`, falling back to `StreamstoneOptions.JsonOptions` when unavailable. The STJ source generator is invoked programmatically at build time via reflection (discovered from loaded build-time assemblies via `StjGenerator.cs`).
 - **Journaled actors**: `[Journaled]` actors always get a generated host-side `ICustomStorageInterface<ActorState, object>` partial (in the silo project via `CloudActors.Streamstone.CodeAnalysis`). `AddStreamstoneActorStorageAsDefault()` / `AddStreamstoneActorStorage(name)` directly call `AddCustomStorageBasedLogConsistencyProvider(name)`, so both the grain storage and log consistency provider are wired together with a single call. Actors using `[Journaled("StateStorage")]` or `[Journaled("LogStorage")]` still get the generated partial, but the interface is dead code since those providers never call `ICustomStorageInterface`.
 - Register via extension methods on `ISiloBuilder`:

--- a/CloudActors.slnx
+++ b/CloudActors.slnx
@@ -1,18 +1,16 @@
 <Solution>
-  <Folder Name="/src/">
-    <Project Path="src/CloudActors.Streamstone.CodeAnalysis/CloudActors.Streamstone.CodeAnalysis.csproj" />
-  </Folder>
   <Project Path="src/CloudActors.Abstractions.CodeAnalysis/CloudActors.Abstractions.CodeAnalysis.csproj" />
   <Project Path="src/CloudActors.Abstractions.CodeFix/CloudActors.Abstractions.CodeFix.csproj" />
   <Project Path="src/CloudActors.Abstractions.Package/CloudActors.Abstractions.Package.msbuildproj" Type="13b669be-bb05-4ddf-9536-439f39a36129" />
-  <Project Path="src/CloudActors.Package/CloudActors.Package.msbuildproj" Type="13b669be-bb05-4ddf-9536-439f39a36129" />
   <Project Path="src/CloudActors.Abstractions/CloudActors.Abstractions.csproj" />
   <Project Path="src/CloudActors.Hosting.CodeAnalysis/CloudActors.Hosting.CodeAnalysis.csproj" />
-  <Project Path="src/CloudActors.Streamstone/CloudActors.Streamstone.csproj" />
   <Project Path="src/CloudActors.Hosting/CloudActors.Hosting.csproj" />
+  <Project Path="src/CloudActors.Package/CloudActors.Package.msbuildproj" Type="13b669be-bb05-4ddf-9536-439f39a36129" />
+  <Project Path="src/CloudActors.Streamstone.CodeAnalysis/CloudActors.Streamstone.CodeAnalysis.csproj" />
+  <Project Path="src/CloudActors.Streamstone/CloudActors.Streamstone.csproj" />
   <Project Path="src/TestApp/TestApp.csproj" Id="457888dc-4899-458c-b5ca-44f01d88be72" />
   <Project Path="src/TestDomain/TestDomain.csproj" />
-  <Project Path="src/Tests/Tests.csproj" />
   <Project Path="src/Tests.CodeAnalysis/Tests.CodeAnalysis.csproj" />
   <Project Path="src/Tests.CodeFix/Tests.CodeFix.csproj" />
+  <Project Path="src/Tests/Tests.csproj" />
 </Solution>

--- a/readme.md
+++ b/readme.md
@@ -298,7 +298,9 @@ public partial class Account : IEventSourced  // 👈 interface is *not* impleme
 When `IEventSourced` is inherited without being implemented, the generator provides the full
 wiring: `Raise<T>(event)` / `Raise<T>()` methods that apply the event and record it in the 
 pending events list, a type-switched `Apply(object)` dispatcher, and `partial void` declarations
-for each event type raised. There is also an optional hook for post-raise callbacks:
+for each event type raised. Event-sourced actors also get a generated protected `ConfirmEvents()`
+helper, which is a safe no-op unless the selected hosting/runtime path wires a persistence
+confirmation callback. There is also an optional hook for post-raise callbacks:
 
 ```csharp
 // Invoked after every Raise<T>(event) call — implement to react to raised events.
@@ -327,6 +329,11 @@ public partial class Account(string id) : IEventSourced
 ```
 
 CloudActors keeps the actor itself as a POCO and generates a `JournaledGrain<Account.ActorState, object>` wrapper behind the scenes. The generated nested `ActorState` becomes the Orleans `TView`, while commands and queries still execute through transient instances of the actor class.
+
+By default, generated journaled grains still auto-`await ConfirmEvents()` after forwarding pending
+events at the end of each command. If you want Orleans-style manual confirmation semantics instead,
+opt into `[Journaled(backgroundSave: true)]` and call `await ConfirmEvents();` explicitly inside the
+actor whenever you want to wait for durability.
 
 `[Journaled]` defaults to whichever backend is configured for JournaledGrainOptions.DefaultLogConsistencyProvider, such as: 
 

--- a/src/CloudActors.Abstractions.CodeAnalysis/ActorState.sbntxt
+++ b/src/CloudActors.Abstractions.CodeAnalysis/ActorState.sbntxt
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.CodeDom.Compiler;
+using System.Threading.Tasks;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Orleans;
@@ -26,6 +27,11 @@ partial class {{ Name }} : IActor<{{ Name }}.ActorState>
         {{~ end ~}}
         {{~if EventSourced && !Journaled ~}}
         state.__actor = this;
+        var confirmable = this as IConfirmableEvents;
+        if (confirmable != null)
+            state.__confirmEvents = confirmable.ConfirmEventsCallback;
+        if (state.__confirmEvents != null && confirmable != null)
+            confirmable.ConfirmEventsCallback = state.__confirmEvents;
         {{~ end ~}}
         return state;
     }
@@ -38,6 +44,11 @@ partial class {{ Name }} : IActor<{{ Name }}.ActorState>
         {{~ end ~}}
         {{~if EventSourced && !Journaled ~}}
         state.__actor = this;
+        var confirmable = this as IConfirmableEvents;
+        if (confirmable != null)
+            state.__confirmEvents = confirmable.ConfirmEventsCallback;
+        if (state.__confirmEvents != null && confirmable != null)
+            confirmable.ConfirmEventsCallback = state.__confirmEvents;
         {{~ end ~}}
         return state;
     }
@@ -73,15 +84,27 @@ partial class {{ Name }} : IActor<{{ Name }}.ActorState>
     }
 
     {{~if EventSourced && !Journaled ~}}
-    partial class ActorState : IEventSourced 
+    partial class ActorState : IEventSourced, IConfirmableEvents
     {
         internal IEventSourced? __actor;
+        internal Func<Task>? __confirmEvents;
 
         IReadOnlyList<object> IEventSourced.Events => __actor?.Events ?? [];
 
         void IEventSourced.AcceptEvents() => __actor?.AcceptEvents();
 
         void IEventSourced.LoadEvents(IEnumerable<object> history) => __actor?.LoadEvents(history);
+
+        Func<Task>? IConfirmableEvents.ConfirmEventsCallback
+        {
+            get => __actor is IConfirmableEvents confirmable ? confirmable.ConfirmEventsCallback : __confirmEvents;
+            set
+            {
+                __confirmEvents = value;
+                if (__actor is IConfirmableEvents confirmable)
+                    confirmable.ConfirmEventsCallback = value;
+            }
+        }
     }
     {{~end~}}
 }

--- a/src/CloudActors.Abstractions.CodeAnalysis/CacheableModels.cs
+++ b/src/CloudActors.Abstractions.CodeAnalysis/CacheableModels.cs
@@ -24,6 +24,7 @@ record struct ActorModel(
     string? StorageProvider,
     bool IsJournaled,
     string? JournaledProviderName,
+    bool JournaledBackgroundSave,
     bool IsEventSourced,
     bool IsPartial,
     EquatableArray<ActorMemberModel> Properties,
@@ -171,10 +172,19 @@ static class ModelExtractors
         var journaled = actor.GetAttributes().FirstOrDefault(x => x.IsJournaled());
         var isJournaled = journaled != null;
         var journaledProvider = default(string);
+        var journaledBackgroundSave = false;
         if (journaled is not null)
         {
-            if (journaled.ConstructorArguments.Length >= 1 && !journaled.ConstructorArguments[0].IsNull)
-                journaledProvider = journaled.ConstructorArguments[0].Value?.ToString();
+            foreach (var argument in journaled.ConstructorArguments)
+            {
+                if (argument.IsNull || argument.Value is null || argument.Type is null)
+                    continue;
+
+                if (argument.Type.SpecialType == SpecialType.System_String)
+                    journaledProvider = argument.Value.ToString();
+                else if (argument.Type.SpecialType == SpecialType.System_Boolean)
+                    journaledBackgroundSave = (bool)argument.Value;
+            }
         }
 
         var ns = actor.ContainingNamespace.IsGlobalNamespace ? "" : actor.ContainingNamespace.ToDisplayString();
@@ -264,6 +274,7 @@ static class ModelExtractors
             StorageProvider: storage,
             IsJournaled: isJournaled,
             JournaledProviderName: journaledProvider,
+            JournaledBackgroundSave: journaledBackgroundSave,
             IsEventSourced: isEventSourced,
             IsPartial: actor.IsPartial(),
             Properties: props,

--- a/src/CloudActors.Abstractions.CodeAnalysis/EventSourced.sbntxt
+++ b/src/CloudActors.Abstractions.CodeAnalysis/EventSourced.sbntxt
@@ -5,6 +5,7 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using Devlooped.CloudActors;
 
@@ -14,14 +15,27 @@ namespace {{ Namespace }};
 
 [GeneratedCode("Devlooped.CloudActors", "{{ Version }}")]
 [CompilerGenerated]
-partial class {{ Name }}
+partial class {{ Name }} : IConfirmableEvents
 {
     /// <summary>List of uncommitted events that have been raised/applied so far.</summary>
     List<object>? events;
+    Func<Task>? confirmEvents;
 
     IReadOnlyList<object> IEventSourced.Events => events ??= new List<object>();
 
     void IEventSourced.AcceptEvents() => events?.Clear();
+
+    Func<Task>? IConfirmableEvents.ConfirmEventsCallback
+    {
+        get => confirmEvents;
+        set => confirmEvents = value;
+    }
+
+    /// <summary>
+    /// Waits for runtime/provider-specific confirmation of previously published events.
+    /// Unless the hosting runtime wires a callback, this method completes immediately.
+    /// </summary>
+    protected Task ConfirmEvents() => confirmEvents?.Invoke() ?? Task.CompletedTask;
 
     void IEventSourced.LoadEvents(IEnumerable<object> history)
     {

--- a/src/CloudActors.Abstractions/IConfirmableEvents.cs
+++ b/src/CloudActors.Abstractions/IConfirmableEvents.cs
@@ -1,0 +1,13 @@
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Devlooped.CloudActors;
+
+/// <summary>Provides an internal bridge for generated actors to await provider-specific event confirmation.</summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IConfirmableEvents
+{
+    /// <summary>Gets or sets the callback used by generated runtime code to await persistence confirmation.</summary>
+    Func<Task>? ConfirmEventsCallback { get; set; }
+}

--- a/src/CloudActors.Abstractions/JournaledAttribute.cs
+++ b/src/CloudActors.Abstractions/JournaledAttribute.cs
@@ -13,7 +13,21 @@ public class JournaledAttribute : Attribute
     /// <remarks>Silo configuration for this provider name is required and will determine the type of backend used.</remarks>
     public JournaledAttribute(string providerName) => ProviderName = providerName;
 
+    /// <summary>Creates a journaled actor declaration with the specified confirmation mode.</summary>
+    public JournaledAttribute(bool backgroundSave) => BackgroundSave = backgroundSave;
+
+    /// <summary>Creates a journaled actor declaration using the specified provider name and confirmation mode.</summary>
+    /// <remarks>Silo configuration for this provider name is required and will determine the type of backend used.</remarks>
+    public JournaledAttribute(string providerName, bool backgroundSave)
+        => (ProviderName, BackgroundSave) = (providerName, backgroundSave);
+
     /// <summary>Log consistency provider used by the generated journaled grain.</summary>
     /// <remarks>Silo configuration for this provider name is required and will determine the type of backend used.</remarks>
     public string? ProviderName { get; }
+
+    /// <summary>
+    /// When <see langword="true"/>, generated journaled grains stop auto-awaiting <c>ConfirmEvents()</c>
+    /// at command completion and instead rely on actor code to explicitly await it when desired.
+    /// </summary>
+    public bool BackgroundSave { get; }
 }

--- a/src/CloudActors.Hosting.CodeAnalysis/ActorGrainGenerator.cs
+++ b/src/CloudActors.Hosting.CodeAnalysis/ActorGrainGenerator.cs
@@ -57,6 +57,7 @@ class ActorGrainGenerator : IIncrementalGenerator
                         actor.StorageProvider,
                         actor.IsJournaled,
                         actor.JournaledProviderName,
+                        actor.JournaledBackgroundSave,
                         Version = ThisAssembly.Info.InformationalVersion,
                         Queries = actor.Queries.AsImmutableArray().Select(q => new { q.Name, q.Type, q.IsAsync }).ToArray(),
                         Commands = actor.Commands.AsImmutableArray().Select(c => new { c.Name, c.Type, c.IsAsync }).ToArray(),

--- a/src/CloudActors.Hosting.CodeAnalysis/JournaledGrain.sbntxt
+++ b/src/CloudActors.Hosting.CodeAnalysis/JournaledGrain.sbntxt
@@ -38,7 +38,12 @@ public partial class {{ Name }}Grain : JournaledGrain<{{ Name }}.ActorState, obj
             ServiceProvider,
             typeof({{ Name }}),
             IdFactory.Create(typeof({{ Name }}), this.GetPrimaryKeyString()));
+
         ((IActor<{{ Name }}.ActorState>)actor).SetState(state);
+
+        if (actor is IConfirmableEvents confirmable)
+            confirmable.ConfirmEventsCallback = ConfirmEvents;
+
         return actor;
     }
 
@@ -81,7 +86,9 @@ public partial class {{ Name }}Grain : JournaledGrain<{{ Name }}.ActorState, obj
                 if (((IEventSourced)actor).Events is { Count: > 0 } events)
                 {
                     RaiseEvents(events);
+                    {{~ if !JournaledBackgroundSave ~}}
                     await ConfirmEvents();
+                    {{~ end ~}}
                 }
                 return (TResult)(object)result;
             }
@@ -107,7 +114,9 @@ public partial class {{ Name }}Grain : JournaledGrain<{{ Name }}.ActorState, obj
                 if (((IEventSourced)actor).Events is { Count: > 0 } events)
                 {
                     RaiseEvents(events);
+                    {{~ if !JournaledBackgroundSave ~}}
                     await ConfirmEvents();
+                    {{~ end ~}}
                 }
                 break;
             }

--- a/src/CloudActors.Hosting/ActorStateFactory.cs
+++ b/src/CloudActors.Hosting/ActorStateFactory.cs
@@ -84,6 +84,9 @@ class ActorStateFactory(IPersistentStateFactory factory, IActorIdFactory idFacto
                     // Don't overwrite state that may already have initial values from actor constructor.
                     if (persistence.RecordExists)
                         Actor.SetState(persistence.State);
+                    else if (persistence.State is IConfirmableEvents stateConfirmable &&
+                        Actor is IConfirmableEvents actorConfirmable)
+                        actorConfirmable.ConfirmEventsCallback = stateConfirmable.ConfirmEventsCallback;
                 }, TaskContinuationOptions.OnlyOnRanToCompletion);
 
         public Task WriteStateAsync()

--- a/src/CloudActors.Streamstone/StreamstoneStorage.cs
+++ b/src/CloudActors.Streamstone/StreamstoneStorage.cs
@@ -77,6 +77,9 @@ public class StreamstoneStorage : IGrainStorage
                 (current, events) => ((IEventSourced)current!).LoadEvents(events));
 
             grainState.State = result.Value;
+            if (grainState.State is IConfirmableEvents confirmable)
+                confirmable.ConfirmEventsCallback = () => options.BackgroundSave ? FlushAsync(stateName, grainId) : Task.CompletedTask;
+
             grainState.ETag = result.Key.ToString();
             grainState.RecordExists = result.Key > 0;
         }

--- a/src/TestDomain/Accounting.cs
+++ b/src/TestDomain/Accounting.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using Devlooped.CloudActors;
 using Moq;
 
@@ -26,9 +27,13 @@ public partial record StateStorageDeposited(decimal Amount);
 
 public partial record StateStorageWithdrawn(decimal Amount);
 
+public partial record BackgroundSaveStateStorageDeposited(decimal Amount);
+
 public partial record LogStorageDeposited(decimal Amount);
 
 public partial record LogStorageWithdrawn(decimal Amount);
+
+public partial record ConfirmTwice(decimal FirstAmount, decimal SecondAmount) : IActorCommand;
 
 public partial record Close(CloseReason Reason = CloseReason.Customer) : IActorCommand<decimal>;
 
@@ -194,6 +199,29 @@ public partial class LogStorageJournaledAccount(string id) : IEventSourced
 
     partial void Apply(LogStorageDeposited e) => Balance += e.Amount;
     partial void Apply(LogStorageWithdrawn e) => Balance -= e.Amount;
+}
+
+[Actor]
+[Journaled("StateStorage", backgroundSave: true)]
+public partial class BackgroundSaveStateStorageJournaledAccount(string id) : IEventSourced
+{
+    [IgnoreDataMember]
+    public string Id => id;
+
+    public decimal Balance { get; private set; }
+
+    public async Task ConfirmTwice(ConfirmTwice command)
+    {
+        Raise(new BackgroundSaveStateStorageDeposited(command.FirstAmount));
+        await ConfirmEvents();
+
+        Raise(new BackgroundSaveStateStorageDeposited(command.SecondAmount));
+        await ConfirmEvents();
+    }
+
+    public decimal Query(GetBalance _) => Balance;
+
+    partial void Apply(BackgroundSaveStateStorageDeposited e) => Balance += e.Amount;
 }
 
 [Actor]

--- a/src/Tests.CodeAnalysis/GrainsGeneration.cs
+++ b/src/Tests.CodeAnalysis/GrainsGeneration.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using Devlooped.CloudActors;
 using Orleans.EventSourcing;
 using Orleans.Runtime;
@@ -62,6 +63,24 @@ public class GrainsGeneration
         Assert.Equal(typeof(JournaledGrain<JournaledActor.ActorState, object>), typeof(JournaledActorGrain).BaseType);
         Assert.False(typeof(IEventSourced).IsAssignableFrom(typeof(JournaledActor.ActorState)));
     }
+
+    [Fact]
+    public void EventSourcedActorGetsConfirmEventsBridge()
+    {
+        Assert.Contains(typeof(IConfirmableEvents), typeof(JournaledActor).GetInterfaces());
+        Assert.NotNull(typeof(JournaledActor).GetMethod("ConfirmEvents", BindingFlags.Instance | BindingFlags.NonPublic));
+        Assert.Contains(typeof(IConfirmableEvents), typeof(StandardEventSourcedActor.ActorState).GetInterfaces());
+        Assert.Null(typeof(ActorWithNoArgs).GetMethod("ConfirmEvents", BindingFlags.Instance | BindingFlags.NonPublic));
+    }
+
+    [Fact]
+    public void JournaledAttributeSupportsBackgroundSave()
+    {
+        var attribute = typeof(BackgroundSaveJournaledActor).GetCustomAttribute<JournaledAttribute>();
+        Assert.NotNull(attribute);
+        Assert.True(attribute!.BackgroundSave);
+        Assert.Equal(typeof(JournaledGrain<BackgroundSaveJournaledActor.ActorState, object>), typeof(BackgroundSaveJournaledActorGrain).BaseType);
+    }
 }
 
 [Actor]
@@ -108,6 +127,41 @@ public partial class JournaledActor(string id) : IEventSourced
     partial void Apply(JournaledDeposited e) => Balance += e.Amount;
 }
 
+[Actor]
+public partial class StandardEventSourcedActor(string id) : IEventSourced
+{
+    [IgnoreDataMember]
+    public string Id => id;
+
+    public decimal Balance { get; private set; }
+
+    public void Deposit(AddFunds _) => Raise(new StandardEventSourcedDeposited(10));
+
+    partial void Apply(StandardEventSourcedDeposited e) => Balance += e.Amount;
+}
+
+[Actor]
+[Journaled(backgroundSave: true)]
+public partial class BackgroundSaveJournaledActor(string id) : IEventSourced
+{
+    [IgnoreDataMember]
+    public string Id => id;
+
+    public decimal Balance { get; private set; }
+
+    public async Task Deposit(AddFunds _)
+    {
+        Raise(new BackgroundSaveJournaledDeposited(10));
+        await ConfirmEvents();
+    }
+
+    public decimal Query(GetBalance _) => Balance;
+
+    partial void Apply(BackgroundSaveJournaledDeposited e) => Balance += e.Amount;
+}
+
 public partial record AddFunds() : IActorCommand;
 public partial record GetBalance() : IActorQuery<decimal>;
 public partial record JournaledDeposited(decimal Amount);
+public partial record StandardEventSourcedDeposited(decimal Amount);
+public partial record BackgroundSaveJournaledDeposited(decimal Amount);

--- a/src/Tests/JournaledOobStorageTests.cs
+++ b/src/Tests/JournaledOobStorageTests.cs
@@ -54,6 +54,16 @@ public class JournaledOobStorageTests(MemoryClusterFixture fixture)
     }
 
     [Fact]
+    public async Task StateStorage_BackgroundSaveActorCanConfirmMidCommand()
+    {
+        await Bus.ExecuteAsync(BackgroundSaveStateStorageJournaledAccount.NewId("ss-bg1"), new ConfirmTwice(100, 25));
+
+        await Cluster.Client.GetGrain<IManagementGrain>(0).ForceActivationCollection(TimeSpan.Zero);
+
+        Assert.Equal(125, await Bus.QueryAsync(BackgroundSaveStateStorageJournaledAccount.NewId("ss-bg1"), GetBalance.Default));
+    }
+
+    [Fact]
     public async Task LogStorage_RoundTrip()
     {
         await Bus.ExecuteAsync(LogStorageJournaledAccount.NewId("ls1"), new Deposit(100));

--- a/src/Tests/StreamstoneTests.cs
+++ b/src/Tests/StreamstoneTests.cs
@@ -220,6 +220,66 @@ public class StreamstoneTests
 
         Assert.Equal(25m, readState.State.Balance);
     }
+
+    [Fact]
+    public async Task BackgroundSave_ConfirmEventsFlushesPendingWriter()
+    {
+        await CloudStorageAccount.DevelopmentStorageAccount
+            .CreateCloudTableClient()
+            .DeleteTableAsync(nameof(ConfirmableAccount));
+
+        var account = new ConfirmableAccount("bgs-confirm-1");
+        var actor = (IActor<ConfirmableAccount.ActorState>)account;
+        var grainId = GrainId.Parse("confirmableaccount/bgs-confirm-1");
+        var storage = new StreamstoneStorage(
+            CloudStorageAccount.DevelopmentStorageAccount,
+            new StreamstoneOptions { BackgroundSave = true });
+
+        var grainState = GrainState.Create(actor.GetState());
+        await storage.ReadStateAsync(nameof(ConfirmableAccount), grainId, grainState);
+        actor.SetState(grainState.State);
+
+        account.Deposit(new Deposit(100));
+        grainState.State = actor.GetState();
+        await storage.WriteStateAsync(nameof(ConfirmableAccount), grainId, grainState);
+
+        await account.WaitForConfirmation();
+
+        var readState = GrainState.Create<ConfirmableAccount.ActorState>(((IActor<ConfirmableAccount.ActorState>)new ConfirmableAccount("bgs-confirm-1")).GetState());
+        await storage.ReadStateAsync(nameof(ConfirmableAccount), grainId, readState);
+
+        Assert.Equal(100m, readState.State.Balance);
+    }
+
+    [Fact]
+    public async Task ConfirmEvents_NoOpsWhenBackgroundSaveDisabled()
+    {
+        await CloudStorageAccount.DevelopmentStorageAccount
+            .CreateCloudTableClient()
+            .DeleteTableAsync(nameof(ConfirmableAccount));
+
+        var account = new ConfirmableAccount("bgs-confirm-2");
+        var actor = (IActor<ConfirmableAccount.ActorState>)account;
+        var grainId = GrainId.Parse("confirmableaccount/bgs-confirm-2");
+        var storage = new StreamstoneStorage(
+            CloudStorageAccount.DevelopmentStorageAccount,
+            new StreamstoneOptions { BackgroundSave = false });
+
+        var grainState = GrainState.Create(actor.GetState());
+        await storage.ReadStateAsync(nameof(ConfirmableAccount), grainId, grainState);
+        actor.SetState(grainState.State);
+
+        account.Deposit(new Deposit(50));
+        grainState.State = actor.GetState();
+        await storage.WriteStateAsync(nameof(ConfirmableAccount), grainId, grainState);
+
+        await account.WaitForConfirmation();
+
+        var readState = GrainState.Create<ConfirmableAccount.ActorState>(((IActor<ConfirmableAccount.ActorState>)new ConfirmableAccount("bgs-confirm-2")).GetState());
+        await storage.ReadStateAsync(nameof(ConfirmableAccount), grainId, readState);
+
+        Assert.Equal(50m, readState.State.Balance);
+    }
 }
 
 
@@ -256,4 +316,20 @@ class GrainState<T>(T state) : IGrainState<T>
 
     public bool RecordExists { get; set; }
 }
+
+[Actor]
+public partial class ConfirmableAccount(string id) : IEventSourced
+{
+    public string Id => id;
+
+    public decimal Balance { get; private set; }
+
+    public void Deposit(Deposit command) => Raise(new ConfirmableDeposited(command.Amount));
+
+    public Task WaitForConfirmation() => ConfirmEvents();
+
+    partial void Apply(ConfirmableDeposited e) => Balance += e.Amount;
+}
+
+public partial record ConfirmableDeposited(decimal Amount);
 


### PR DESCRIPTION
Event sourced actors can now optionally opt-in to explicitly confirming events, so that persistence providers that support background saving can do so while allowing critical actor sections to await for event confirmation from storage.

This feature integrates seamlessly with JournaledGrain in Orleans via the [Journaled(backgroundSave: true)] which causes the default behavior for to be the same as for classic journaled grains (background save and optional explicit awaiting to confirm events from user code.